### PR TITLE
fix deadlock

### DIFF
--- a/src/scrapyscript/__init__.py
+++ b/src/scrapyscript/__init__.py
@@ -88,10 +88,11 @@ class Processor(Process):
 
         p = Process(target=self._crawl, args=[jobs])
         p.start()
+        results = self.results.get()
         p.join()
         p.terminate()
 
-        return self.results.get()
+        return results
 
     def validate(self, jobs):
         if not all([isinstance(x, Job) for x in jobs]):


### PR DESCRIPTION
Remove items from queue before the process is joined and prevent
deadlock.

Should fix https://github.com/jschnurr/scrapyscript/issues/3

Fixed by: @covuworie