### PR TITLE
grant additional control to determine what logging settings should be honored

### DIFF
--- a/src/scrapyscript/__init__.py
+++ b/src/scrapyscript/__init__.py
@@ -40,7 +40,7 @@ class Processor(Process):
     Blocks until all have finished.
     """
 
-    def __init__(self, settings=None):
+    def __init__(self, settings=None, install_root_handler=True):
         """
         Parms:
           settings (scrapy.settings.Settings) - settings to apply.  Defaults
@@ -51,6 +51,7 @@ class Processor(Process):
         self.results = Queue(**kwargs)
         self.items = []
         self.settings = settings or Settings()
+        self.install_root_handler = install_root_handler
         dispatcher.connect(self._item_scraped, signals.item_scraped)
 
     def _item_scraped(self, item):
@@ -62,7 +63,10 @@ class Processor(Process):
             requests (Request) - One or more Jobs. All will
                                  be loaded into a single invocation of the reactor.
         """
-        self.crawler = CrawlerProcess(self.settings)
+        self.crawler = CrawlerProcess(
+            settings=self.settings,
+            install_root_handler=self.install_root_handler,
+        )
 
         # crawl can be called multiple times to queue several requests
         for req in requests:

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -16,9 +16,11 @@ def celery_job(url):
 
 
 @app.task
-def celery_job_with_custom_settings(url, settings):
+def celery_job_with_custom_settings(url, settings, install_root_handler):
     job = Job(ItemSpider, url=url)
-    return Processor(settings=settings).run(job)
+    return Processor(settings=settings, install_root_handler=install_root_handler).run(
+        job
+    )
 
 
 class TestScrapyScriptCelery:
@@ -32,7 +34,7 @@ class TestScrapyScriptCelery:
         settings["BOT_NAME"] = "alpha"
 
         task = celery_job_with_custom_settings.s(
-            "https://www.python.org", settings
+            "https://www.python.org", settings, False
         ).apply()
         print(task.result[0])
         assert task.result[0]["bot"] == "alpha"


### PR DESCRIPTION
Scrapy will by default attach a new root logger to a CrawlerProcess.  There is a controllable boolean present in scrapy these days to configure this, so I've created a passthrough boolean with the same name, etc. to attach to it.  Otherwise, celery and scrapy fight over control of logging and make it rather hard to keep settings consistent.